### PR TITLE
Support Rails 4 & use Gemfile not gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 .idea
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,11 @@
 source 'https://rubygems.org'
-ruby "1.9.3"
+ruby '2.5.8'
+#ruby-gemset=gem_has_dynamic_status_types
 gemspec
+
+group :test do
+  gem 'bundler', '~> 1.3'
+  gem 'rake'
+  gem 'sqlite3'
+  gem 'timecop'
+end

--- a/has_dynamic_status_types.gemspec
+++ b/has_dynamic_status_types.gemspec
@@ -4,24 +4,24 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'has_dynamic_status_types/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "has_dynamic_status_types"
+  spec.name          = 'has_dynamic_status_types'
   spec.version       = HasDynamicStatusTypes::VERSION
-  spec.authors       = ["Benjamin Martin"]
-  spec.email         = ["benjamin@salemaster.co.uk"]
+  spec.authors       = ['Benjamin Martin']
+  spec.email         = ['benjamin@salemaster.co.uk']
   spec.description   = %q{Add differenet statuses to your models}
   spec.summary       = %q{Models can has different statuses, but different flavours of the same model the same status might mean something else .. crazy!}
-  spec.homepage      = "http://www.salesmaster.co.uk"
-  spec.license       = "MIT"
+  spec.homepage      = 'http://www.salesmaster.co.uk'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "timecop"
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'timecop'
 
-  spec.add_dependency 'activerecord', '~> 3.2.14'
+  spec.add_dependency 'activerecord', '>=3.2.1', '<5.0'
 end

--- a/has_dynamic_status_types.gemspec
+++ b/has_dynamic_status_types.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = HasDynamicStatusTypes::VERSION
   spec.authors       = ['Benjamin Martin']
   spec.email         = ['benjamin@salemaster.co.uk']
-  spec.description   = %q{Add differenet statuses to your models}
+  spec.description   = %q{Add different statuses to your models}
   spec.summary       = %q{Models can has different statuses, but different flavours of the same model the same status might mean something else .. crazy!}
   spec.homepage      = 'http://www.salesmaster.co.uk'
   spec.license       = 'MIT'
@@ -17,11 +17,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-
-  spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'timecop'
 
   spec.add_dependency 'activerecord', '>=3.2.1', '<5.0'
 end

--- a/lib/has_dynamic_status_types/association.rb
+++ b/lib/has_dynamic_status_types/association.rb
@@ -5,8 +5,6 @@ class HasDynamicStatusTypes::Association < ActiveRecord::Base
 
   belongs_to :status_typeable, polymorphic: true
 
-  attr_accessible :status_type, :current_status_code
-
   before_save do |record|
     hist = self.history
     hist << { code: self.current_status_code, when: DateTime.now }
@@ -17,5 +15,4 @@ class HasDynamicStatusTypes::Association < ActiveRecord::Base
     return [] unless self.previous_statuses_codes
     return YAML.load(self.previous_statuses_codes)
   end
-
 end


### PR DESCRIPTION
This PR provides Rails 4 support and modifies gem dependencies to use the Gemfile rather than gemspec to allow test dependencies to be excluded when bundling on production environments.